### PR TITLE
pytest-rerunfailures 16.1 

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,2 @@
 build_env_vars:
-  ANACONDA_ROCKET_ENABLE_PY313 : yes
+  ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,44 +1,42 @@
 {% set name = "pytest-rerunfailures" %}
-{% set version = "13.0" %}
+{% set version = "16.1" %}
 
 package:
-  name: "{{ name|lower }}"
-  version: "{{ version }}"
+  name: {{ name }}
+  version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: e132dbe420bc476f544b96e7036edd0a69707574209b6677263c950d19b09199
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_')}}-{{ version }}.tar.gz
+  sha256: c38b266db8a808953ebd71ac25c381cb1981a78ff9340a14bcb9f1b9bff1899e
 
 build:
   number: 0
-  skip: True # [py<37]
   script: {{ PYTHON }} -m pip install . -vv --no-build-isolation --no-deps
+  skip: true # [py<310]
 
 requirements:
   host:
     - pip
     - python
-    - setuptools >=40.0
     - wheel
+    - setuptools >=40.0
   run:
     - python
     - packaging >=17.1
-    - pytest >=7
-  run_constrained:
-    - pytest-xdist >=2.3.0
+    - pytest >=7.4,!=8.2.2
 
 test:
+  source_files:
+    - tests
   imports:
     - pytest_rerunfailures
-  requires:
-    - pip
-  source_files:
-    - test_pytest_rerunfailures.py
   commands:
     - pip check
     # Skipping tests that are known to fail due to improper class teardown between runs.
     # https://github.com/pytest-dev/pytest-rerunfailures/issues/268
-    - pytest -vv . -k "not test_run_session_teardown_once_after_reruns"
+    - pytest -v tests -k "not test_run_session_teardown_once_after_reruns"
+  requires:
+    - pip
 
 about:
   home: https://github.com/pytest-dev/pytest-rerunfailures


### PR DESCRIPTION
pytest-rerunfailures 16.1 

**Destination channel:** Defaults

### Links

- [PKG-11645]
- dev_url:        https://github.com/pytest-dev/pytest-rerunfailures/tree/16.1
- conda_forge:    https://github.com/conda-forge/pytest-rerunfailures-feedstock
- pypi:           https://pypi.org/project/pytest-rerunfailures/16.1
- pypi inspector: https://inspector.pypi.io/project/pytest-rerunfailures/16.1

### Explanation of changes:

- new version number


[PKG-11645]: https://anaconda.atlassian.net/browse/PKG-11645?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ